### PR TITLE
PEP625, normalize name for package

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -11,7 +11,6 @@ on:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -22,21 +21,20 @@ jobs:
     if: "!contains(github.event.head_commit.message, 'skip ci')"
     
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         python -m pip install torch
-        $CONDA/bin/conda install pytorch -c pytorch
-        pip install -e .
+        python -m pip install -e .[test]
     
     - name: Test with pytest
       run: |
-        python setup.py test
+        pytest --cov=SFC_Torch --cov-report=xml
     
     - name: Upload coverage to Codecov  
       uses: codecov/codecov-action@v3

--- a/.github/workflows/Publish.yml
+++ b/.github/workflows/Publish.yml
@@ -16,11 +16,13 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install packaging setuptools twine wheel
+        pip install build packaging setuptools twine wheel
+    - name: Build package
+      run: |
+        python -m build
     - name: Publish the Python package
       env:
         TWINE_USERNAME: __token__
         TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
       run: |
-        python setup.py sdist bdist_wheel
         twine upload dist/*

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ def getVersionNumber():
 
 __version__ = getVersionNumber()
 
-setup(name="SFcalculator_torch",
+setup(name="sfcalculator_torch",
     version=__version__,
     author="Minhaun Li",
     license="MIT",

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ setup(name="sfcalculator_torch",
         "numpy<2.0.0",
         "tqdm",
     ],
-    setup_requires=["pytest-runner"],
-    tests_require=["pytest", "pytest-cov"],
+    extras_require={
+        "test": ["pytest", "pytest-cov"]
+    },
 )


### PR DESCRIPTION
I got the following notice from PyPI:

> This email is notifying you of an upcoming deprecation that we have determined may affect you as a result of your recent upload to 'SFcalculator-torch'.
In the future, PyPI will require all newly uploaded source distribution filenames to comply with PEP 625. Any source distributions already uploaded will remain in place as-is and do not need to be updated.
Specifically, your recent upload of 'SFcalculator_torch-0.2.3.tar.gz' is incompatible with PEP 625 because the filename does not contain the normalized project name 'sfcalculator_torch'.
In most cases, this can be resolved by upgrading the version of your build tooling to a later version that supports PEP 625 and produces compliant filenames. You do not need to remove the file.
If you have questions, you can email admin@pypi.org to communicate with the PyPI admin@pypi.org to communicate with the PyPI administrators.

I made corresponding changes in my CI flow and package name to account for that.

In the future users would be advised to do 


```
pip install sfcalculator_torch
``` 

But `pip install SFcalculator_torch` would also work just not recommended.