### PR TITLE
Fix broken documentation link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ![Build](https://github.com/Hekstra-Lab/SFcalculator_torch/workflows/Build/badge.svg)
 [![codecov](https://codecov.io/github/Hekstra-Lab/SFcalculator_torch/branch/master/graph/badge.svg?token=02GUPGPUC1)](https://codecov.io/github/Hekstra-Lab/SFcalculator_torch)
 [![PyPI](https://img.shields.io/pypi/v/SFcalculator-torch?color=blue)](https://pypi.org/project/SFcalculator-torch/)
-[![Tutorial](https://img.shields.io/badge/Page-Tutorial-violet)](https://hekstra-lab.github.io/SFcalculator_torch/)
+[![Tutorial](https://img.shields.io/badge/Page-Tutorial-violet)](https://rs-station.github.io/SFcalculator_torch/)
 [![BioRXiv](https://img.shields.io/badge/BioRXiv-10.1101%2F2025.01.12.632630v2-b31b1b?)](https://www.biorxiv.org/content/10.1101/2025.01.12.632630v2)
 
 
@@ -20,7 +20,7 @@ To install this package:
     pip install SFcalculator-torch
     ```
  
-For a walkthrough tutorial, check this page: https://hekstra-lab.github.io/SFcalculator_torch/
+For a walkthrough tutorial, check this page: https://rs-station.github.io/SFcalculator_torch/
 
 ### Citing
 


### PR DESCRIPTION
## Summary
- Updates the tutorial/docs URL from `hekstra-lab.github.io` to `rs-station.github.io` in two places in the README (badge and inline link)

Closes #35